### PR TITLE
Fix license name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     classifiers=[
-        'License :: OSI Approved :: MIT',
+        'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Topic :: Software Development',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The name of the License in the `setup.py` was wrong. This prevented us from uploading to PyPi