### PR TITLE
bump requests to 2.27.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.1 (Mar 2022)
 
  - Bump `paramiko` to version 2.8.1
+ - Bump `requests` to version 2.27.1
 
 # 1.0.0 (Sep 2021)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     license="MIT",
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
-        "requests==2.22.0",
+        "requests==2.27.1",
         "attrs==19.3.0",
         "pysftp==0.2.9",
         "paramiko==2.8.1",


### PR DESCRIPTION
Also bumping `requests` for 1.0.1 release to resolve dependency conflicts